### PR TITLE
Fix dependencies

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,9 @@
 
+Release notes for SOAP::WSDL 3.003
+-------
+
+o. change the base module for SOAP::WSDL::SOAP::HeaderFault to SOAP::WSDL::SOAP::Header instead of inexisting module SOAP::WSDL::Header
+
 Release notes for SOAP::WSDL 3.002
 
 o. change each file from having their own version number to referring to $SOAP::WSDL::VERSION since they aren't really individually versions anyway but just copies of that numbe

--- a/lib/SOAP/WSDL.pm
+++ b/lib/SOAP/WSDL.pm
@@ -14,7 +14,7 @@ use Class::Std::Fast constructor => 'none';
 use SOAP::WSDL::XSD::Typelib::Builtin::anySimpleType;
 use LWP::UserAgent;
 
-use version; our $VERSION = qv('3.002');
+use version; our $VERSION = qv('3.003');
 
 my %no_dispatch_of      :ATTR(:name<no_dispatch>);
 my %wsdl_of             :ATTR(:name<wsdl>);

--- a/lib/SOAP/WSDL/SOAP/HeaderFault.pm
+++ b/lib/SOAP/WSDL/SOAP/HeaderFault.pm
@@ -1,7 +1,7 @@
 package SOAP::WSDL::SOAP::HeaderFault;
 use strict;
 use warnings;
-use base qw(SOAP::WSDL::Header);
+use base qw(SOAP::WSDL::SOAP::Header);
 
 our $VERSION = $SOAP::WSDL::VERSION;
 


### PR DESCRIPTION
I believe the package SOAP::WSDL::SOAP::HeaderFault had a erroneous use base of 
SOAP::WSDL::Header instead of 
SOAP::WSDL::**SOAP**::Header

Bump version for new release.