### PR TITLE
Tell GitHub our test files are Perl 5, not Perl 6

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.t linguist-language=Perl


### PR DESCRIPTION
Currently, GitHub erroneously reports this repo uses Perl 5 and Perl 6, with test files reported as being Perl 6.

This pull fixes the issue.