### PR TITLE
Fix failing tests

### DIFF
--- a/lib/SOAP/WSDL.pm
+++ b/lib/SOAP/WSDL.pm
@@ -529,6 +529,22 @@ SOAP call to the SOAP service. Handy for testing/debugging.
 Returns the SOAP client implementation used (normally a SOAP::WSDL::Client
 object).
 
+=head2 Undocumented methods
+
+=head3 proxy
+
+=head3 get_proxy
+
+=head3 set_proxy
+
+=head3 keep_alive
+
+=head3 outputhash
+
+=head3 set_readable
+
+=head3 wsdl
+
 =head1 EXAMPLES
 
 See the examples/ directory.

--- a/lib/SOAP/WSDL/Client.pm
+++ b/lib/SOAP/WSDL/Client.pm
@@ -383,6 +383,22 @@ SOAP::WSDL::Client and implementing something like
 You may even do this in a class factory - see L<wsdl2perl.pl> for creating
 such interfaces.
 
+=head2 Undocumented methods
+
+=head3 class_resolver
+
+=head3 get_proxy
+
+=head3 no_dispatch
+
+=head3 prefix
+
+=head3 proxy
+
+=head3 set_proxy
+
+=head3 set_soap_version
+
 =head1 TROUBLESHOOTING
 
 =head2 Accessing protected web services

--- a/lib/SOAP/WSDL/Expat/Base.pm
+++ b/lib/SOAP/WSDL/Expat/Base.pm
@@ -118,6 +118,36 @@ SOAP::WSDL::Expat::Base - Base class for XML::Parser::Expat based XML parsers
 Base class for XML::Parser::Expat based XML parsers. All XML::SAX::Expat based
 parsers in SOAP::WSDL inherit from this class.
 
+=head2 Undocumented methods
+
+=head3 clone
+
+=head3 get_data
+
+=head3 get_uri
+
+=head3 get_user_agent
+
+=head3 is_parsed
+
+=head3 new
+
+=head3 parse
+
+=head3 parse_file
+
+=head3 parse_string
+
+=head3 parse_uri
+
+=head3 parsefile
+
+=head3 set_parsed
+
+=head3 set_uri
+
+=head3 set_user_agent
+
 =head1 AUTHOR
 
 Replace the whitespace by @ for E-Mail Address.

--- a/lib/SOAP/WSDL/Expat/MessageParser.pm
+++ b/lib/SOAP/WSDL/Expat/MessageParser.pm
@@ -315,6 +315,16 @@ child elements you want to skip.
 
 =back
 
+=head2 Undocumented methods
+
+=head3 class_resolver
+
+=head3 get_header
+
+=head3 load_classes
+
+=head3 new
+
 =head1 AUTHOR
 
 Replace the whitespace by @ for E-Mail Address.

--- a/lib/SOAP/WSDL/Expat/MessageStreamParser.pm
+++ b/lib/SOAP/WSDL/Expat/MessageStreamParser.pm
@@ -52,6 +52,16 @@ ExpatNB based parser for parsing huge documents.
 
 See L<SOAP::WSDL::Manual::Parser> for details.
 
+=head2 Undocumented methods
+
+=head3 init
+
+=head3 parse_done
+
+=head3 parse_more
+
+=head3 parse_start
+
 =head1 Bugs and Limitations
 
 See SOAP::WSDL::Expat::MessageParser

--- a/lib/SOAP/WSDL/Expat/WSDLParser.pm
+++ b/lib/SOAP/WSDL/Expat/WSDLParser.pm
@@ -352,6 +352,12 @@ SOAP::WSDL::Expat::WSDLParser - Parse WSDL files into object trees
 
 WSDL parser used by SOAP::WSDL.
 
+=head2 Undocumented methods
+
+=head3 wsdl_import
+
+=head3 xml_schema_import
+
 =head1 AUTHOR
 
 Replace the whitespace by @ for E-Mail Address.

--- a/lib/SOAP/WSDL/Generator/Iterator/WSDL11.pm
+++ b/lib/SOAP/WSDL/Generator/Iterator/WSDL11.pm
@@ -159,6 +159,14 @@ The iterator performs a depth-first search along the following path:
 If you wonder about this path: This is how to look up which XML Schema element
 is associated with a operation from a service/port.
 
+=head2 Undocumented methods
+
+=head3 get_next
+
+=head3 get_nextNodes
+
+=head3 init
+
 =head2 Example
 
 The nodes are returned in the order denoted in the following example:

--- a/lib/SOAP/WSDL/Generator/Template/Plugin/XSD.pm
+++ b/lib/SOAP/WSDL/Generator/Template/Plugin/XSD.pm
@@ -196,6 +196,28 @@ perl_name takes a crude approach by just replacing . and - (dot and dash)
 with a underscore. This may or may not be sufficient, and may or may not
 provoke collisions in your XML names.
 
+=head2 Undocumented methods
+
+=head3 create_interface_name
+
+=head3 create_server_name
+
+=head3 create_subpackage_name
+
+=head3 create_typemap_name
+
+=head3 create_xmlattr_name
+
+=head3 create_xsd_name
+
+=head3 element_name
+
+=head3 load
+
+=head3 new
+
+=head3 perl_var_name
+
 =head1 LICENSE AND COPYRIGHT
 
 Copyright 2008 Martin Kutter.

--- a/lib/SOAP/WSDL/Generator/Visitor/Typemap.pm
+++ b/lib/SOAP/WSDL/Generator/Visitor/Typemap.pm
@@ -195,6 +195,18 @@ SOAP::WSDL::Generator::Visitor::Typemap - Visitor class for generating typemaps
 
 Visitor used by SOAP::WSDL's XSD generator for creating typemaps
 
+=head2 Undocumented methods
+
+=head3 add_element_path
+
+=head3 process_referenced_type
+
+=head3 set_typemap_entry
+
+=head3 visit_XSD_ComplexType
+
+=head3 visit_XSD_Element
+
 =head1 AUTHOR
 
 Replace the whitespace by @ for E-Mail Address.

--- a/lib/SOAP/WSDL/SOAP/Typelib/Fault.pm
+++ b/lib/SOAP/WSDL/SOAP/Typelib/Fault.pm
@@ -6,3 +6,13 @@ use Class::Std::Fast::Storable constructor => 'none';
 our $VERSION = 3.004;
 
 1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+SOAP::WSDL::SOAP::Typelib::Fault
+
+=cut

--- a/lib/SOAP/WSDL/SOAP/Typelib/Fault11.pm
+++ b/lib/SOAP/WSDL/SOAP/Typelib/Fault11.pm
@@ -149,6 +149,12 @@ a detail object.
 Note that passing a list of detail object is currently not supported (though
 the SOAP1.1 note allows this).
 
+=head2 Undocumented methods
+
+=head3 as_bool
+
+=head3 get_xmlns
+
 =head1 LICENSE AND COPYRIGHT
 
 Copyright 2007 Martin Kutter. All rights reserved.

--- a/lib/SOAP/WSDL/Server/Mod_Perl2.pm
+++ b/lib/SOAP/WSDL/Server/Mod_Perl2.pm
@@ -221,6 +221,12 @@ handle() is called with the following parameters:
 
  $r - Apache::RequestRec object
 
+=head2 Undocumented methods
+
+=head3 handle
+
+=head3 handler
+
 =head1 EXAMPLES
 
 The following snippet added to httpd.conf will enable a SOAP server at

--- a/lib/SOAP/WSDL/Transport/HTTP.pm
+++ b/lib/SOAP/WSDL/Transport/HTTP.pm
@@ -85,6 +85,18 @@ SOAP::WSDL::Transport::HTTP - Fallback http(s) transport class
 Provides a thin transport class used by SOAP::WSDL::Transport when
 SOAP::Lite is not available.
 
+=head2 Undocumented methods
+
+=head3 code
+
+=head3 is_success
+
+=head3 message
+
+=head3 send_receive
+
+=head3 status
+
 =head1 LICENSE AND COPYRIGHT
 
 Copyright (c) 2007 Martin Kutter. All rights reserved.

--- a/lib/SOAP/WSDL/Transport/Loopback.pm
+++ b/lib/SOAP/WSDL/Transport/Loopback.pm
@@ -55,6 +55,18 @@ When SOAP::WSDL::Transport::Loopback is used as transport backend, the
 request is returned as response. No data ever goes over the wire.
 This is particularly useful for testing SOAP::WSDL plugins and applications.
 
+=head2 Undocumented methods
+
+=head3 code
+
+=head3 is_success
+
+=head3 message
+
+=head3 send_receive
+
+=head3 status
+
 =head1 LICENSE AND COPYRIGHT
 
 Copyright (c) 2007 Martin Kutter. All rights reserved.

--- a/lib/SOAP/WSDL/Transport/Test.pm
+++ b/lib/SOAP/WSDL/Transport/Test.pm
@@ -108,6 +108,18 @@ Examples:
 Sets the base directory SOAP::WSDL::Transport::Test should look for response
 files.
 
+=head2 Undocumented methods
+
+=head3 code
+
+=head3 is_success
+
+=head3 message
+
+=head3 send_receive
+
+=head3 status
+
 =head1 LICENSE AND COPYRIGHT
 
 Copyright (c) 2007 Martin Kutter. All rights reserved.

--- a/lib/SOAP/WSDL/XSD/Typelib/ComplexType.pm
+++ b/lib/SOAP/WSDL/XSD/Typelib/ComplexType.pm
@@ -632,6 +632,10 @@ Serialize a complexType's attributes
 Serialize a ComplexType object to XML. Exported via symbol table into derived
 classes.
 
+=head2 Undocumented methods
+
+=head3 get_xmlns
+
 =head1 Bugs and limitations
 
 =over

--- a/lib/SOAP/WSDL/XSD/Typelib/Element.pm
+++ b/lib/SOAP/WSDL/XSD/Typelib/Element.pm
@@ -126,6 +126,14 @@ Now we create this XML schema definition type class:
  __PACKAGE__->__set_nillable(0);
  __PACKAGE__->__set_ref(1);
 
+=head1 DESCRIPTION
+
+=head2 Undocumented methods
+
+=head3 end_tag
+
+=head3 start_tag
+
 =head1 NOTES
 
 =over

--- a/t/094_cpan_meta.t
+++ b/t/094_cpan_meta.t
@@ -1,4 +1,4 @@
-use Test::More;
+use Test::More tests => 2;
 
 if (not $ENV{RELEASE_TESTING} ) {
     my $msg = 'Author test.  Set $ENV{RELEASE_TESTING} to a true value to run.';
@@ -8,4 +8,4 @@ if (not $ENV{RELEASE_TESTING} ) {
 eval { require Test::CPAN::Meta }
     or plan skip_all => "Test::CPAN::Meta required for testing META.yml";
 
-Test::CPAN::Meta::meta_yaml_ok();
+Test::CPAN::Meta::meta_spec_ok(q(MYMETA.yml));

--- a/t/095_copying.t
+++ b/t/095_copying.t
@@ -11,6 +11,9 @@ require Test::Pod::Content;
 import Test::Pod::Content;
 
 my $dir = 'blib/lib';
+plan skip_all => qq(No directory $dir)
+    unless -e $dir;
+
 if (-d '../t') {
     $dir = '../lib';
 }

--- a/t/096_characters.t
+++ b/t/096_characters.t
@@ -18,6 +18,9 @@ my @skip = (
 );
 
 my $dir = 'blib/lib';
+plan skip_all => qq(No directory $dir)
+    unless -e $dir;
+
 if (-d '../t') {
     $dir = '../lib';
 }

--- a/t/099_pod_coverage.t
+++ b/t/099_pod_coverage.t
@@ -62,15 +62,21 @@ else {                  # we are outside t/
 
 plan tests => scalar @files;
 foreach (@files) {
-    pod_coverage_ok( $_ ,
-    {
-        private => [
-           qr/^_/,
-           qr/^BUILD$/,
-           qr/^START$/,
-           qr/^STORABLE/,
-           qr/^AUTOMETHOD$/,
-           qr/^DEMOLISH$/
-           ]
-    });
-}
+SKIP: {
+        eval qq(require $_);
+        skip qq(Unable to require $_: $@) => 1
+            if $@;
+
+        pod_coverage_ok( $_,
+        {
+            private => [
+                qr/^_/,
+                qr/^BUILD$/,
+                qr/^START$/,
+                qr/^STORABLE/,
+                qr/^AUTOMETHOD$/,
+                qr/^DEMOLISH$/
+            ]
+        });
+    } ## end SKIP:
+} ## end foreach (@files)


### PR DESCRIPTION
When executing the tests i received a bunch of useless errors:

```
$ RELEASE_TESTING=1 prove -l
t/002_parse_wsdl.t ............... ok     
t/003_wsdl_based_serializer.t .... ok     
t/006_client.t ................... ok     
t/008_client_wsdl_complexType.t .. ok   
t/009_data_classes.t ............. ok   
t/011_simpleType.t ............... ok    
t/012_element.t .................. ok    
t/013_complexType.t .............. ok   
t/016_client_object.t ............ ok     
t/094_cpan_meta.t ................ 1/2 
#   Failed test 'META.yml contains valid YAML'
#   at /home/marc0/perl5/lib/perl5/Test/CPAN/Meta.pm line 104.

#   Failed test 'META.yml meets the designated specification'
#   at /home/marc0/perl5/lib/perl5/Test/CPAN/Meta.pm line 104.
#   ERR: can't open META.yml for reading: No such file or directory at /home/marc0/perl5/lib/perl5/Parse/CPAN/Meta.pm line 122.
# Looks like you failed 2 tests of 2.
t/094_cpan_meta.t ................ Dubious, test returned 2 (wstat 512, 0x200)
Failed 2/2 subtests 
t/095_copying.t .................. Can't stat blib/lib: No such file or directory
 at t/095_copying.t line 19.
You said to run 0 tests at t/095_copying.t line 74.
t/095_copying.t .................. Dubious, test returned 2 (wstat 512, 0x200)
No subtests run 
t/096_characters.t ............... Can't stat blib/lib: No such file or directory
 at t/096_characters.t line 26.
You said to run 0 tests at t/096_characters.t line 35.
t/096_characters.t ............... Dubious, test returned 2 (wstat 512, 0x200)
No subtests run 
t/097_kwalitee.t ................. ok    
t/098_pod.t ...................... ok       
t/099_pod_coverage.t ............. 1/38 
#   Failed test 'Pod coverage on SOAP::WSDL'
#   at t/099_pod_coverage.t line 65.
# Coverage for SOAP::WSDL is 63.2%, with 7 naked subroutines:
# 	get_proxy
# 	keep_alive
# 	outputhash
# 	proxy
# 	set_proxy
# 	set_readable
# 	wsdl

#   Failed test 'Pod coverage on SOAP::WSDL::Client'
#   at t/099_pod_coverage.t line 65.
# Coverage for SOAP::WSDL::Client is 22.2%, with 7 naked subroutines:
# 	class_resolver
# 	get_proxy
# 	no_dispatch
# 	prefix
# 	proxy
# 	set_proxy
# 	set_soap_version

#   Failed test 'Pod coverage on SOAP::WSDL::Expat::MessageStreamParser'
#   at t/099_pod_coverage.t line 65.
# Coverage for SOAP::WSDL::Expat::MessageStreamParser is 0.0%, with 4 naked subroutines:
# 	init
# 	parse_done
# 	parse_more
# 	parse_start

#   Failed test 'Pod coverage on SOAP::WSDL::Expat::Base'
#   at t/099_pod_coverage.t line 65.
# Coverage for SOAP::WSDL::Expat::Base is 0.0%, with 14 naked subroutines:
# 	clone
# 	get_data
# 	get_uri
# 	get_user_agent
# 	is_parsed
# 	new
# 	parse
# 	parse_file
# 	parse_string
# 	parse_uri
# 	parsefile
# 	set_parsed
# 	set_uri
# 	set_user_agent

#   Failed test 'Pod coverage on SOAP::WSDL::Expat::WSDLParser'
#   at t/099_pod_coverage.t line 65.
# Coverage for SOAP::WSDL::Expat::WSDLParser is 0.0%, with 2 naked subroutines:
# 	wsdl_import
# 	xml_schema_import

#   Failed test 'Pod coverage on SOAP::WSDL::Expat::MessageParser'
#   at t/099_pod_coverage.t line 65.
# Coverage for SOAP::WSDL::Expat::MessageParser is 0.0%, with 4 naked subroutines:
# 	class_resolver
# 	get_header
# 	load_classes
# 	new

#   Failed test 'Pod coverage on SOAP::WSDL::Server::Mod_Perl2'
#   at t/099_pod_coverage.t line 65.
# Coverage for SOAP::WSDL::Server::Mod_Perl2 is 0.0%, with 2 naked subroutines:
# 	handle
# 	handler

#   Failed test 'Pod coverage on SOAP::WSDL::Transport::Test'
#   at t/099_pod_coverage.t line 65.
# Coverage for SOAP::WSDL::Transport::Test is 0.0%, with 5 naked subroutines:
# 	code
# 	is_success
# 	message
# 	send_receive
# 	status

#   Failed test 'Pod coverage on SOAP::WSDL::Transport::Loopback'
#   at t/099_pod_coverage.t line 65.
# Coverage for SOAP::WSDL::Transport::Loopback is 0.0%, with 5 naked subroutines:
# 	code
# 	is_success
# 	message
# 	send_receive
# 	status

#   Failed test 'Pod coverage on SOAP::WSDL::Transport::HTTP'
#   at t/099_pod_coverage.t line 65.
# Coverage for SOAP::WSDL::Transport::HTTP is 0.0%, with 5 naked subroutines:
# 	code
# 	is_success
# 	message
# 	send_receive
# 	status

#   Failed test 'Pod coverage on SOAP::WSDL::Generator::Iterator::WSDL11'
#   at t/099_pod_coverage.t line 65.
# Coverage for SOAP::WSDL::Generator::Iterator::WSDL11 is 0.0%, with 3 naked subroutines:
# 	get_next
# 	get_nextNodes
# 	init

#   Failed test 'Pod coverage on SOAP::WSDL::Generator::Visitor::Typemap'
#   at t/099_pod_coverage.t line 65.
# Coverage for SOAP::WSDL::Generator::Visitor::Typemap is 0.0%, with 5 naked subroutines:
# 	add_element_path
# 	process_referenced_type
# 	set_typemap_entry
# 	visit_XSD_ComplexType
# 	visit_XSD_Element

#   Failed test 'Pod coverage on SOAP::WSDL::XSD::Typelib::Element'
#   at t/099_pod_coverage.t line 65.
# Coverage for SOAP::WSDL::XSD::Typelib::Element is 0.0%, with 2 naked subroutines:
# 	end_tag
# 	start_tag

#   Failed test 'Pod coverage on SOAP::WSDL::XSD::Typelib::ComplexType'
#   at t/099_pod_coverage.t line 65.
# Coverage for SOAP::WSDL::XSD::Typelib::ComplexType is 80.0%, with 1 naked subroutine:
# 	get_xmlns

#   Failed test 'Pod coverage on SOAP::WSDL::SOAP::Typelib::Fault'
#   at t/099_pod_coverage.t line 65.
# SOAP::WSDL::SOAP::Typelib::Fault: couldn't find pod

#   Failed test 'Pod coverage on SOAP::WSDL::SOAP::Typelib::Fault11'
#   at t/099_pod_coverage.t line 65.
# Coverage for SOAP::WSDL::SOAP::Typelib::Fault11 is 0.0%, with 2 naked subroutines:
# 	as_bool
# 	get_xmlns

#   Failed test 'Pod coverage on SOAP::WSDL::Generator::Template::Plugin::XSD'
#   at t/099_pod_coverage.t line 65.
# Coverage for SOAP::WSDL::Generator::Template::Plugin::XSD is 9.1%, with 10 naked subroutines:
# 	create_interface_name
# 	create_server_name
# 	create_subpackage_name
# 	create_typemap_name
# 	create_xmlattr_name
# 	create_xsd_name
# 	element_name
# 	load
# 	new
# 	perl_var_name
# Looks like you failed 17 tests of 38.
t/099_pod_coverage.t ............. Dubious, test returned 17 (wstat 4352, 0x1100)
Failed 17/38 subtests 

Test Summary Report
-------------------
t/094_cpan_meta.t              (Wstat: 512 Tests: 2 Failed: 2)
  Failed tests:  1-2
  Non-zero exit status: 2
t/095_copying.t                (Wstat: 512 Tests: 0 Failed: 0)
  Non-zero exit status: 2
  Parse errors: No plan found in TAP output
t/096_characters.t             (Wstat: 512 Tests: 0 Failed: 0)
  Non-zero exit status: 2
  Parse errors: No plan found in TAP output
t/099_pod_coverage.t           (Wstat: 4352 Tests: 38 Failed: 17)
  Failed tests:  1-2, 12-15, 20, 24-26, 29-30, 32-33, 36-38
  Non-zero exit status: 17
Files=15, Tests=304,  5 wallclock secs ( 0.09 usr  0.04 sys +  3.66 cusr  0.27 csys =  4.06 CPU)
Result: FAIL
```

They are fixed for me by the given patches.